### PR TITLE
fix(UI): show password error next to a password check label

### DIFF
--- a/app/src/main/java/com/example/soenapp/RegisterActivity.java
+++ b/app/src/main/java/com/example/soenapp/RegisterActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
+import android.widget.TextView;
 import android.widget.Toast;
 
 public class RegisterActivity extends AppCompatActivity {
@@ -14,6 +15,7 @@ public class RegisterActivity extends AppCompatActivity {
     EditText makeID;
     EditText makePW;
     EditText makePW_check;
+    TextView pwIncorrectError;
     Button next;
 
     @Override
@@ -25,7 +27,10 @@ public class RegisterActivity extends AppCompatActivity {
         makeID = findViewById(R.id.newID);
         makePW = findViewById(R.id.newPW);
         makePW_check = findViewById(R.id.newPW_check);
+        pwIncorrectError = findViewById(R.id.password_error);
         next = findViewById(R.id.next);
+
+        pwIncorrectError.setText("");
 
         final Intent intent = new Intent(getApplicationContext(), RegisterSchoolActivity.class);
         next.setOnClickListener(new View.OnClickListener() {
@@ -38,6 +43,8 @@ public class RegisterActivity extends AppCompatActivity {
 
                 if (!(name.equals("")) || !(id.equals("")) || !(pw.equals("")) || !(pw_check.equals(""))) {
                     if (pw.equals(pw_check)) {
+                        pwIncorrectError.setText("");
+
                         intent.putExtra("name", name);
                         intent.putExtra("id", id);
                         intent.putExtra("pw", pw);
@@ -45,7 +52,7 @@ public class RegisterActivity extends AppCompatActivity {
                         startActivity(intent);
 
                     } else {
-                        Toast.makeText(getApplicationContext(), "비밀번호가 일치하지 않습니다.", Toast.LENGTH_SHORT).show();
+                        pwIncorrectError.setText(R.string.error_incorrect_password);
                     }
                 }
             }

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -78,12 +78,34 @@
                     android:background="@drawable/rounded_edittext"
                     android:hint="@string/text_pw" />
 
-                <TextView
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="@string/text_pw_check"
-                    android:textColor="@android:color/black"
-                    android:textSize="16sp" />
+                    android:orientation="horizontal">
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/text_pw_check"
+                        android:textColor="@android:color/black"
+                        android:textSize="16sp"
+                        android:layout_gravity="center"/>
+
+                    <View
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"/>
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textColor="#FF0000"
+                        android:text="@string/error_incorrect_password"
+                        android:textSize="13sp"
+                        android:layout_gravity="center"
+                        android:id="@+id/password_error"/>
+
+                </LinearLayout>
 
                 <EditText
                     android:id="@+id/newPW_check"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <string name="hint_school_search">학교명 입력</string>
     <string name="text_school_search">학교검색</string>
     <string name="error_invalid_password">비밀번호가 너무 짧습니다.</string>
-    <string name="error_incorrect_password">비밀번호가 올바르지 않습니다.</string>
+    <string name="error_incorrect_password">비밀번호가 일치하지 않습니다.</string>
     <string name="error_field_required">내용을 입력해 주세요.</string>
 
     <!-- Strings related to buttons -->


### PR DESCRIPTION
EditText 옆에 오류를 표시하게 되면 비밀번호가 가려지게 되는 문제가 있어서 '비밀번호 확인' TextView 옆에 표시하는 방법으로 변경함.

closes: #16