### PR TITLE
fix(UI): Redesign login screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,11 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.soenapp">
     <!-- To auto-complete the email text field in the login form with the user's emails -->
-    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
-    <uses-permission android:name="android.permission.READ_PROFILE" />
-    <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.INTERNET" />
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -14,7 +9,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.NoActionBar">
-        <activity android:name=".RegisterCompletedActivity"></activity>
+        <activity android:name=".TestActivity"></activity>
+        <activity android:name=".RegisterCompletedActivity" />
         <activity android:name=".MainActivity" />
         <activity android:name=".ChatActivity" />
         <activity android:name=".LoginActivity">
@@ -27,5 +23,10 @@
         <activity android:name=".RegisterSchoolActivity" />
         <activity android:name=".RegisterActivity" />
     </application>
+    <uses-permission android:name="android.permission.READ_PROFILE" />
+    <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 
 </manifest>

--- a/app/src/main/java/com/example/soenapp/LoginActivity.java
+++ b/app/src/main/java/com/example/soenapp/LoginActivity.java
@@ -23,7 +23,7 @@ public class LoginActivity extends AppCompatActivity {
 
     EditText editID, editPW;
     String id, pw;
-    Button login, register;
+    Button login, register, test;
 
     SharedPreferences sharedPreferences;
     SharedPreferences.Editor editor;
@@ -49,6 +49,8 @@ public class LoginActivity extends AppCompatActivity {
         editPW = findViewById(R.id.PW);
         login = findViewById(R.id.login_bt);
         register = findViewById(R.id.register_bt);
+
+        test = findViewById(R.id.btn_test_screen);
 
         sharedPreferences = getSharedPreferences("appData", MODE_PRIVATE);
 
@@ -93,21 +95,12 @@ public class LoginActivity extends AppCompatActivity {
             }
         });
 
-        //채팅 화면 테스트 (임시)
-        findViewById(R.id.go_to_chat).setOnClickListener(new View.OnClickListener() {
+        // 테스트 화면 버튼
+        test.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                final Intent chat_intent = new Intent(getApplicationContext(), ChatActivity.class);
-                startActivity(chat_intent);
-            }
-        });
-
-        //메인 화면 테스트 (임시)
-        findViewById(R.id.go_to_main).setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                final Intent main_intent = new Intent(getApplicationContext(), MainActivity.class);
-                startActivity(main_intent);
+                final Intent intent = new Intent(getApplicationContext(), TestActivity.class);
+                startActivity(intent);
             }
         });
 

--- a/app/src/main/java/com/example/soenapp/TestActivity.java
+++ b/app/src/main/java/com/example/soenapp/TestActivity.java
@@ -1,0 +1,39 @@
+package com.example.soenapp;
+
+import android.content.Intent;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
+
+public class TestActivity extends AppCompatActivity {
+
+    Button goToChat, goToMain;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_test);
+
+        goToChat = findViewById(R.id.go_to_chat);
+        goToMain = findViewById(R.id.go_to_main);
+
+        // 채팅 화면 테스트
+        goToChat.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                final Intent intent = new Intent(getApplicationContext(), ChatActivity.class);
+                startActivity(intent);
+            }
+        });
+
+        // 메인 화면 테스트
+        goToMain.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                final Intent intent = new Intent(getApplicationContext(), MainActivity.class);
+                startActivity(intent);
+            }
+        });
+    }
+}

--- a/app/src/main/res/drawable/rounded_edittext.xml
+++ b/app/src/main/res/drawable/rounded_edittext.xml
@@ -6,8 +6,8 @@
     <solid
         android:color="#FFFFFF"/>
     <corners
-        android:bottomRightRadius="15dp"
-        android:bottomLeftRadius="15dp"
-        android:topLeftRadius="15dp"
-        android:topRightRadius="15dp"/>
+        android:bottomRightRadius="40dp"
+        android:bottomLeftRadius="40dp"
+        android:topLeftRadius="40dp"
+        android:topRightRadius="40dp"/>
 </shape>

--- a/app/src/main/res/drawable/shape_button.xml
+++ b/app/src/main/res/drawable/shape_button.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    android:padding="10dp">
+    <solid
+        android:color="@color/colorGrey"/>
+    <corners
+        android:bottomRightRadius="40dp"
+        android:bottomLeftRadius="40dp"
+        android:topLeftRadius="40dp"
+        android:topRightRadius="40dp"/>
+</shape>

--- a/app/src/main/res/drawable/shape_button_accent.xml
+++ b/app/src/main/res/drawable/shape_button_accent.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle"
+    android:padding="10dp">
+    <solid
+        android:color="@android:color/holo_blue_dark"/>
+    <corners
+        android:bottomRightRadius="40dp"
+        android:bottomLeftRadius="40dp"
+        android:topLeftRadius="40dp"
+        android:topRightRadius="40dp"/>
+</shape>

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -7,24 +7,6 @@
     tools:context=".LoginActivity"
     android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        android:layout_marginTop="@dimen/title_marginTop">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginStart="@dimen/title_marginStart"
-            android:text="@string/action_sign_in"
-            android:textColor="@android:color/black"
-            android:textSize="50sp"
-            android:textStyle="bold" />
-
-    </LinearLayout>
-
     <android.support.constraint.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -37,6 +19,15 @@
             android:orientation="vertical"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/action_sign_in"
+                android:textColor="@android:color/black"
+                android:textSize="50sp"
+                android:textStyle="bold" />
 
             <LinearLayout
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -98,26 +98,14 @@
 
             </LinearLayout>
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <Button
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/test_chat_screen"
-                    android:id="@+id/go_to_chat"/>
-
-                <Button
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/test_main_screen"
-                    android:id="@+id/go_to_main"/>
-
-            </LinearLayout>
-
         </LinearLayout>
+
+        <Button
+            android:layout_width="20dp"
+            android:layout_height="30dp"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:id="@+id/btn_test_screen"/>
 
     </android.support.constraint.ConstraintLayout>
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -10,84 +10,115 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
-        android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        android:orientation="horizontal"
+        android:layout_marginTop="@dimen/title_marginTop">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginStart="@dimen/title_marginStart"
+            android:text="@string/action_sign_in"
+            android:textColor="@android:color/black"
+            android:textSize="50sp"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
             android:orientation="vertical"
-            android:layout_margin="30dp">
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
 
-            <TextView
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_margin="30dp">
+
+                <EditText
+                    android:id="@+id/ID"
+                    android:layout_gravity="center"
+                    android:layout_marginBottom="10dp"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:maxLines="1"
+                    android:hint="@string/text_id"
+                    android:inputType="text"
+                    android:background="@drawable/rounded_edittext" />
+
+                <EditText
+                    android:id="@+id/PW"
+                    android:layout_gravity="center"
+                    android:layout_width="match_parent"
+                    android:layout_height="60dp"
+                    android:maxLines="1"
+                    android:hint="@string/text_pw"
+                    android:inputType="textPassword"
+                    android:background="@drawable/rounded_edittext"/>
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:layout_marginTop="20dp">
+
+                    <Button
+                        android:id="@+id/login_bt"
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:layout_gravity="center"
+                        android:layout_weight="1"
+                        android:layout_marginHorizontal="10dp"
+                        android:background="@drawable/shape_button_accent"
+                        android:text="@string/action_sign_in"
+                        android:textSize="20sp"
+                        android:textColor="@color/colorWhite" />
+
+                    <Button
+                        android:layout_width="match_parent"
+                        android:layout_height="50dp"
+                        android:id="@+id/register_bt"
+                        android:layout_weight="1"
+                        android:layout_marginHorizontal="10dp"
+                        android:background="@drawable/shape_button"
+                        android:text="@string/action_sign_up"
+                        android:textSize="20sp"
+                        android:textColor="@color/colorWhite"/>
+
+                </LinearLayout>
+
+            </LinearLayout>
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginTop="30dp"
-                android:text="@string/action_sign_in"
-                android:textColor="@android:color/black"
-                android:textSize="50sp" />
+                android:orientation="horizontal">
 
-            <EditText
-                android:id="@+id/ID"
-                android:layout_gravity="center"
-                android:layout_width="match_parent"
-                android:layout_height="60dp"
-                android:maxLines="1"
-                android:hint="@string/text_id" />
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/test_chat_screen"
+                    android:id="@+id/go_to_chat"/>
 
-            <EditText
-                android:id="@+id/PW"
-                android:layout_gravity="center"
-                android:layout_width="match_parent"
-                android:layout_height="60dp"
-                android:maxLines="1"
-                android:hint="@string/text_pw" />
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/test_main_screen"
+                    android:id="@+id/go_to_main"/>
 
-            <Button
-                android:id="@+id/login_bt"
-                android:layout_width="match_parent"
-                android:layout_height="60dp"
-                android:layout_marginTop="15dp"
-                android:background="@android:color/holo_blue_dark"
-                android:text="@string/action_sign_in"
-                android:textSize="20sp"
-                android:textColor="@color/colorWhite"/>
-
-            <Button
-                android:layout_width="match_parent"
-                android:layout_height="60dp"
-                android:layout_marginTop="10dp"
-                android:id="@+id/register_bt"
-                android:background="@color/colorGrey"
-                android:text="@string/action_sign_up"
-                android:textSize="20sp"
-                android:textColor="@color/colorWhite"/>
+            </LinearLayout>
 
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
+    </android.support.constraint.ConstraintLayout>
 
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/test_chat_screen"
-                android:id="@+id/go_to_chat"/>
-
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/test_main_screen"
-                android:id="@+id/go_to_main"/>
-
-        </LinearLayout>
-
-    </LinearLayout>
-
-</android.support.constraint.ConstraintLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -11,7 +11,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="20dp">
+        android:layout_marginTop="@dimen/title_marginTop">
 
         <TextView
             android:layout_width="wrap_content"
@@ -19,7 +19,7 @@
             android:text="@string/text_main"
             android:textSize="50sp"
             android:textColor="#000000"
-            android:layout_marginStart="30dp"
+            android:layout_marginStart="@dimen/title_marginStart"
             android:textStyle="bold"
             android:layout_gravity="center"
             android:id="@+id/mode"/>

--- a/app/src/main/res/layout/activity_test.xml
+++ b/app/src/main/res/layout/activity_test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".TestActivity"
+    android:orientation="vertical">
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/test_main_screen"
+        android:id="@+id/go_to_main"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/test_chat_screen"
+        android:id="@+id/go_to_chat"/>
+
+</LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -3,4 +3,7 @@
     <dimen name="activity_horizontal_margin">16dp</dimen>
     <dimen name="activity_vertical_margin">16dp</dimen>
     <dimen name="fab_margin">16dp</dimen>
+
+    <dimen name="title_marginTop">20dp</dimen>
+    <dimen name="title_marginStart">30dp</dimen>
 </resources>


### PR DESCRIPTION
* 제목(로그인) 글자 굵기 변경
* 아이디, 비밀번호 입력 칸 모양 변경
* 로그인, 회원가입 버튼 모양, 위치 변경
* 하단 테스트 버튼들을 삭제, 왼쪽 하단에 조그만 버튼을 배치해 테스트 화면을 따로 만들었음.
closes: #20 
<img width="551" alt="스크린샷 2019-09-28 오전 11 59 30" src="https://user-images.githubusercontent.com/48079406/65810620-70f04400-e1e7-11e9-9012-26f57fbf07d6.png">
<img width="551" alt="스크린샷 2019-09-28 오후 12 03 05" src="https://user-images.githubusercontent.com/48079406/65810657-f3790380-e1e7-11e9-8ae5-9f91308f15f2.png">
