### PR TITLE
fix(UI): Redesign register screen

### DIFF
--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -24,21 +24,25 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginTop="30dp"
-                android:text="@string/action_sign_up"
+                android:layout_marginStart="@dimen/marginStart_title"
+                android:layout_marginBottom="30dp"
+                android:text="@string/text_info"
                 android:textColor="@android:color/black"
-                android:textSize="50sp" />
+                android:textSize="@dimen/textSize_title"
+                android:textStyle="bold"/>
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="30dp"
+                android:layout_marginStart="25dp"
+                android:layout_marginEnd="25dp"
                 android:orientation="vertical">
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/marginStart_text_above_rounded_edittext"
+                    android:layout_marginBottom="@dimen/marginBottom_text_above_rounded_edittext"
                     android:text="@string/text_name"
                     android:textColor="@android:color/black"
                     android:textSize="@dimen/textSize_small" />
@@ -48,11 +52,16 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_edittext"
-                    android:hint="@string/text_name" />
+                    android:hint="@string/text_name"
+                    android:layout_marginBottom="10dp"
+                    android:paddingStart="@dimen/paddingStart_rounded_edittext"
+                    android:paddingEnd="0dp"/>
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/marginStart_text_above_rounded_edittext"
+                    android:layout_marginBottom="@dimen/marginBottom_text_above_rounded_edittext"
                     android:text="@string/text_id"
                     android:textColor="@android:color/black"
                     android:textSize="@dimen/textSize_small" />
@@ -62,11 +71,16 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_edittext"
-                    android:hint="@string/text_id" />
+                    android:hint="@string/text_id"
+                    android:layout_marginBottom="10dp"
+                    android:paddingStart="@dimen/paddingStart_rounded_edittext"
+                    android:paddingEnd="0dp"/>
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/marginStart_text_above_rounded_edittext"
+                    android:layout_marginBottom="@dimen/marginBottom_text_above_rounded_edittext"
                     android:text="@string/text_pw"
                     android:textColor="@android:color/black"
                     android:textSize="@dimen/textSize_small" />
@@ -76,17 +90,23 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_edittext"
-                    android:hint="@string/text_pw" />
+                    android:hint="@string/text_pw"
+                    android:inputType="textPassword"
+                    android:layout_marginBottom="10dp"
+                    android:paddingStart="@dimen/paddingStart_rounded_edittext"
+                    android:paddingEnd="0dp"/>
 
                 <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:orientation="horizontal"
+                    android:layout_marginBottom="@dimen/marginBottom_text_above_rounded_edittext">
 
                     <TextView
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:text="@string/text_pw_check"
+                        android:layout_marginStart="@dimen/marginStart_text_above_rounded_edittext"
                         android:textColor="@android:color/black"
                         android:textSize="@dimen/textSize_small"
                         android:layout_gravity="center"/>
@@ -112,17 +132,20 @@
                     android:layout_width="match_parent"
                     android:layout_height="50dp"
                     android:background="@drawable/rounded_edittext"
-                    android:hint="@string/text_pw" />
+                    android:hint="@string/text_pw_check"
+                    android:inputType="textPassword"
+                    android:layout_marginBottom="30dp"
+                    android:paddingStart="@dimen/paddingStart_rounded_edittext"
+                    android:paddingEnd="0dp"/>
 
                 <Button
                     android:id="@+id/next"
                     android:layout_width="130dp"
                     android:layout_height="wrap_content"
-                    android:background="@android:color/holo_blue_dark"
+                    android:background="@drawable/shape_button_accent"
                     android:textColor="#ffffff"
                     android:textSize="20sp"
                     android:layout_gravity="end"
-                    android:layout_marginTop="20dp"
                     android:text="@string/action_next" />
 
             </LinearLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,6 +7,11 @@
     <!-- margin -->
     <dimen name="marginTop_title">20dp</dimen>
     <dimen name="marginStart_title">30dp</dimen>
+    <dimen name="marginStart_text_above_rounded_edittext">10.5dp</dimen>
+    <dimen name="marginBottom_text_above_rounded_edittext">5dp</dimen>
+
+    <!-- padding -->
+    <dimen name="paddingStart_rounded_edittext">10dp</dimen>
 
     <!-- textSize -->
     <dimen name="textSize_title">50sp</dimen>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,7 @@
     <!-- Strings related to login -->
     <string name="action_sign_in">로그인</string>
     <string name="action_sign_up">회원가입</string>
+    <string name="action_enter_info">정보 입력</string>
     <string name="text_id">아이디</string>
     <string name="text_id_en">ID</string>
     <string name="text_pw">비밀번호</string>
@@ -41,6 +42,9 @@
     <string name="action_message">메시지</string>
 
     <!-- Sort by Activities -->
+
+    <!-- activity_register -->
+    <string name="text_info">정보</string>
 
     <!-- activity_register_completed -->
     <string name="text_register_completed_your_name">홍길동님,</string>


### PR DESCRIPTION
회원가입 시 정보 입력 화면을 개편함.
* 제목(회원가입)이 "정보"로 변경됨.
* 제목과 입력 칸들 사이의 간격이 넓어짐.
* 제목의 위치 변경, 글씨체가 굵어짐.
* 입력 칸 위에 있는 TextView와 입력 칸인 EditText 사이에 간격이 생김.
* TextView와 Edittext, 그리고 Button이 있는 Layout의 너비가 길어짐.
* TextView와 Edittext 묶음들 간의 간격이 생김.
* 다음 Button과 입력 칸들 사이의 간격이 넓어짐.
* 다음 Button의 모양이 변경됨.

closes: #22

![Screenshot_1569656724](https://user-images.githubusercontent.com/48079406/65813374-80838300-e20f-11e9-95ec-48e7541f110a.png)
