### PR TITLE
fix(UI): Redesign register school screen

### DIFF
--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -25,7 +25,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/marginStart_title"
-                android:layout_marginBottom="30dp"
+                android:layout_marginBottom="@dimen/marginBottom_title"
                 android:text="@string/text_info"
                 android:textColor="@android:color/black"
                 android:textSize="@dimen/textSize_title"

--- a/app/src/main/res/layout/activity_register_school.xml
+++ b/app/src/main/res/layout/activity_register_school.xml
@@ -10,77 +10,54 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"
         android:orientation="vertical"
         app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="100dp"
-            android:text="@string/action_sign_up"
-            android:textColor="@android:color/black"
-            android:textSize="50sp" />
+            android:text="@string/text_school_search"
+            android:textColor="@color/colorBlack"
+            android:textSize="@dimen/textSize_title"
+            android:textStyle="bold"
+            android:layout_marginStart="@dimen/marginStart_title"
+            android:layout_marginTop="@dimen/marginTop_title"
+            android:layout_marginBottom="@dimen/marginBottom_title" />
 
-        <LinearLayout
+        <EditText
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="30dp"
-            android:orientation="vertical">
+            android:layout_height="50dp"
+            android:id="@+id/input"
+            android:hint="@string/hint_school_search"
+            android:background="@drawable/rounded_edittext"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="30dp"
+            android:paddingStart="@dimen/paddingStart_rounded_edittext"
+            android:paddingEnd="0dp"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/text_school_search"
-                android:textColor="#000000"
-                android:textSize="16sp"/>
-
-            <EditText
-                android:layout_width="match_parent"
-                android:layout_height="50dp"
-                android:id="@+id/input"
-                android:hint="@string/hint_school_search"
-                android:background="@drawable/rounded_edittext"/>
-
-        </LinearLayout>
-
-        <LinearLayout
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/school_list"
+            android:scrollbars="vertical"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginLeft="30dp"
-            android:layout_marginRight="30dp">
-
-            <android.support.v7.widget.RecyclerView
-                android:id="@+id/school_list"
-                android:scrollbars="vertical"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:layout_marginLeft="8dp"
-            android:layout_marginRight="8dp">
-
-            <Button
-                android:id="@+id/next"
-                android:layout_width="130dp"
-                android:layout_height="wrap_content"
-                android:background="@android:color/holo_blue_dark"
-                android:textColor="#ffffff"
-                android:textSize="20sp"
-                android:layout_gravity="end"
-                android:layout_marginTop="20dp"
-                android:text="@string/action_next" />
-
-        </LinearLayout>
+            android:layout_height="match_parent"
+            android:layout_marginTop="10dp"
+            android:layout_marginStart="30dp"
+            android:layout_marginEnd="30dp"/>
 
     </LinearLayout>
+
+        <Button
+            android:id="@+id/next"
+            android:layout_width="130dp"
+            android:layout_height="wrap_content"
+            android:background="@drawable/shape_button_accent"
+            android:textColor="#ffffff"
+            android:textSize="20sp"
+            android:layout_gravity="end"
+            android:text="@string/action_next"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            android:layout_marginEnd="30dp"
+            android:layout_marginBottom="30dp"/>
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -7,6 +7,7 @@
     <!-- margin -->
     <dimen name="marginTop_title">20dp</dimen>
     <dimen name="marginStart_title">30dp</dimen>
+    <dimen name="marginBottom_title">30dp</dimen>
     <dimen name="marginStart_text_above_rounded_edittext">10.5dp</dimen>
     <dimen name="marginBottom_text_above_rounded_edittext">5dp</dimen>
 


### PR DESCRIPTION
회원가입 중 학교검색 페이지의 디자인을 전체적으로 개편함.
* 제목(회원가입)을 "학교검색"으로 변경함.
* 제목의 위치가 변경됨.
* 제목의 글씨체가 굵어짐.
* 학교명 입력 칸 위에 있던 "학교검색" TextView는 삭제됨.
* 학교명 입력 칸(EditText)과 그 안의 텍스트가 붙어 있지 않도록 하였음.
* Button의 모양이 변경됨.
* Button의 위치를 고정하여 RecyclerView의 목록이 길어질 때 Button이 내려가지 않도록 하였음.

closes: #24

![Screenshot_1569659558](https://user-images.githubusercontent.com/48079406/65813997-3bfbe580-e217-11e9-99ac-2cc4d2cccb6f.png)
