### PR TITLE
fix(UI): Redesign register completed screen

### DIFF
--- a/app/src/main/res/layout/activity_register_completed.xml
+++ b/app/src/main/res/layout/activity_register_completed.xml
@@ -7,33 +7,27 @@
     tools:context=".RegisterCompletedActivity"
     android:orientation="vertical">
 
+
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:text="@string/action_sign_up"
-            android:layout_gravity="center"
-            android:textSize="50sp"
-            android:textColor="#000000" />
+        android:layout_margin="30dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent">
 
         <LinearLayout
-            android:layout_width="match_parent"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
-            android:layout_margin="30dp">
+            android:layout_gravity="center">
 
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/text_register_completed_your_name"
                 android:textSize="35sp"
-                android:layout_gravity="center"
+                android:textStyle="bold"
                 android:textColor="#000000"
                 android:id="@+id/name"/>
 
@@ -43,69 +37,76 @@
                 android:text="@string/text_register_completed_message"
                 android:layout_gravity="center"
                 android:textSize="25sp"
+                android:textColor="@color/colorBlack"
                 android:layout_marginTop="10dp"/>
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="vertical"
-                android:layout_margin="60dp">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/text_id"
-                    android:textColor="#000000"
-                    android:textSize="15sp"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/sample_id"
-                    android:textSize="20sp"
-                    android:id="@+id/id"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/text_pw"
-                    android:textColor="#000000"
-                    android:textSize="15sp"
-                    android:layout_marginTop="12dp" />
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/sample_pw"
-                    android:textSize="20sp"
-                    android:id="@+id/pw"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/text_school"
-                    android:textColor="#000000"
-                    android:textSize="15sp"
-                    android:layout_marginTop="12dp"/>
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/sample_school"
-                    android:textSize="20sp"
-                    android:id="@+id/school"/>
-
-            </LinearLayout>
-
-            <Button
-                android:layout_width="match_parent"
-                android:layout_height="60dp"
-                android:text="@string/action_go_to_login_screen"
-                android:textSize="20sp"
-                android:id="@+id/go_to_login"/>
 
         </LinearLayout>
 
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:layout_marginLeft="40dp"
+            android:layout_marginRight="40dp"
+            android:layout_marginTop="30dp"
+            android:layout_marginBottom="30dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/text_id"
+                android:textColor="#000000"
+                android:textSize="15sp"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sample_id"
+                android:textSize="20sp"
+                android:id="@+id/id"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/text_pw"
+                android:textColor="#000000"
+                android:textSize="15sp"
+                android:layout_marginTop="12dp" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sample_pw"
+                android:textSize="20sp"
+                android:id="@+id/pw"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/text_school"
+                android:textColor="#000000"
+                android:textSize="15sp"
+                android:layout_marginTop="12dp"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/sample_school"
+                android:textSize="20sp"
+                android:id="@+id/school"/>
+
+        </LinearLayout>
+
+        <Button
+            android:layout_width="match_parent"
+            android:layout_height="60dp"
+            android:background="@drawable/shape_button"
+            android:text="@string/action_go_to_login_screen"
+            android:textSize="20sp"
+            android:textColor="@color/colorWhite"
+            android:id="@+id/go_to_login"/>
+
     </LinearLayout>
+
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
회원가입 완료 화면의 전체적인 디자인이 개편됨.
* 회원가입 메시지의 모양이 바뀜.
* "로그인 화면으로 가기" Button의 모양과 색깔이 바뀜.

closes: #26

![Screenshot_1569662433](https://user-images.githubusercontent.com/48079406/65814448-b67b3400-e21c-11e9-85ed-c4d3ba1c8ac3.png)
