### PR TITLE
fix: Location of sender and time is asymmetric

### DIFF
--- a/app/src/main/java/com/example/soenapp/ChatAdapter.java
+++ b/app/src/main/java/com/example/soenapp/ChatAdapter.java
@@ -18,7 +18,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
     private List<ChatData> mDataset;
     private String myUserKey;
 
-    static class MyViewHolder extends RecyclerView.ViewHolder{
+    private View myView;
+
+    class MyViewHolder extends RecyclerView.ViewHolder {
 
         TextView chatText, chatPerson, chatTimeRight, chatTimeLeft;
         LinearLayout layoutChatObject, layoutChatContainer,
@@ -26,6 +28,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
 
         MyViewHolder(View v) {
             super(v);
+            myView = v;
             chatText = v.findViewById(R.id.chat_text);
             chatPerson = v.findViewById(R.id.chat_person);
             chatTimeRight = v.findViewById(R.id.chat_time_right);
@@ -57,13 +60,10 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
 
         holder.chatText.setText(mDataset.get(position).text);
         holder.chatPerson.setText(mDataset.get(position).person);
-//        holder.chatTimeRight.setText(mDataset.get(position).time);
 
-        // myUserKey 가 메시지의 user_key 와 일치할 때
-        // mDataset.user_key 는 서버에서 받아 오는 값임
-        // myUserKey 는 로그인했을 때 SharedPreferences 에 저장되어 있는 값임
         LinearLayout.LayoutParams floor1LayoutParams = (LinearLayout.LayoutParams) holder.layoutChatFloor1.getLayoutParams();
         LinearLayout.LayoutParams floor2LayoutParams = (LinearLayout.LayoutParams) holder.layoutChatFloor2.getLayoutParams();
+        LinearLayout.LayoutParams nameLayoutParams = (LinearLayout.LayoutParams) holder.chatPerson.getLayoutParams();
 
         // 내가 보낸 메시지일 경우
         if (myUserKey.equals(mDataset.get(position).user_key)) {
@@ -75,6 +75,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
             holder.layoutChatFloor1.setLayoutParams(floor1LayoutParams);
             holder.layoutChatFloor2.setLayoutParams(floor2LayoutParams);
 
+            nameLayoutParams.leftMargin = (int) myView.getResources().getDimension(R.dimen.margin_between_name_time);
+            nameLayoutParams.rightMargin = 0;
+            holder.chatPerson.setLayoutParams(nameLayoutParams);
             holder.chatTimeLeft.setText(mDataset.get(position).time);
             holder.chatTimeRight.setText("");
         } else {  // 다른 사람이 보낸 메시지일 경우
@@ -86,6 +89,9 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
             holder.layoutChatFloor1.setLayoutParams(floor1LayoutParams);
             holder.layoutChatFloor2.setLayoutParams(floor2LayoutParams);
 
+            nameLayoutParams.leftMargin = 0;
+            nameLayoutParams.rightMargin = (int) myView.getResources().getDimension(R.dimen.margin_between_name_time);
+            holder.chatPerson.setLayoutParams(nameLayoutParams);
             holder.chatTimeRight.setText(mDataset.get(position).time);
             holder.chatTimeLeft.setText("");
         }

--- a/app/src/main/java/com/example/soenapp/ChatAdapter.java
+++ b/app/src/main/java/com/example/soenapp/ChatAdapter.java
@@ -1,5 +1,6 @@
 package com.example.soenapp;
 
+import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -17,17 +18,18 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
     private List<ChatData> mDataset;
     private String myUserKey;
 
-    public static class MyViewHolder extends RecyclerView.ViewHolder{
+    static class MyViewHolder extends RecyclerView.ViewHolder{
 
-        public TextView chat_text, chat_person, chat_time;
-        public LinearLayout layoutChatObject, layoutChatContainer,
+        TextView chatText, chatPerson, chatTimeRight, chatTimeLeft;
+        LinearLayout layoutChatObject, layoutChatContainer,
                             layoutChatFloor1, layoutChatFloor2;
 
-        public MyViewHolder(View v) {
+        MyViewHolder(View v) {
             super(v);
-            chat_text = v.findViewById(R.id.chat_text);
-            chat_person = v.findViewById(R.id.chat_person);
-            chat_time = v.findViewById(R.id.chat_time);
+            chatText = v.findViewById(R.id.chat_text);
+            chatPerson = v.findViewById(R.id.chat_person);
+            chatTimeRight = v.findViewById(R.id.chat_time_right);
+            chatTimeLeft = v.findViewById(R.id.chat_time_left);
 
             layoutChatObject = v.findViewById(R.id.layout_chat_object);
             layoutChatContainer = v.findViewById(R.id.layout_chat_container);
@@ -36,11 +38,12 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
         }
     }
 
-    public ChatAdapter(List<ChatData> myDataset, String my_user_key) {
+    ChatAdapter(List<ChatData> myDataset, String my_user_key) {
         mDataset = myDataset;
         myUserKey = my_user_key;
     }
 
+    @NonNull
     @Override
     public ChatAdapter.MyViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View v = LayoutInflater.from(parent.getContext())
@@ -51,11 +54,10 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
     // Replace the contents of a view (invoked by the layout manager)
     @Override
     public void onBindViewHolder(MyViewHolder holder, int position) {
-        // - get element from your dataset at this position
-        // - replace the contents of the view with that element
-        holder.chat_text.setText(mDataset.get(position).text);
-        holder.chat_person.setText(mDataset.get(position).person);
-        holder.chat_time.setText(mDataset.get(position).time);
+
+        holder.chatText.setText(mDataset.get(position).text);
+        holder.chatPerson.setText(mDataset.get(position).person);
+//        holder.chatTimeRight.setText(mDataset.get(position).time);
 
         // myUserKey 가 메시지의 user_key 와 일치할 때
         // mDataset.user_key 는 서버에서 받아 오는 값임
@@ -63,6 +65,7 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
         LinearLayout.LayoutParams floor1LayoutParams = (LinearLayout.LayoutParams) holder.layoutChatFloor1.getLayoutParams();
         LinearLayout.LayoutParams floor2LayoutParams = (LinearLayout.LayoutParams) holder.layoutChatFloor2.getLayoutParams();
 
+        // 내가 보낸 메시지일 경우
         if (myUserKey.equals(mDataset.get(position).user_key)) {
             holder.layoutChatObject.setGravity(Gravity.END);
             holder.layoutChatContainer.setBackgroundResource(chat_box_me);
@@ -71,7 +74,10 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
             floor2LayoutParams.gravity = Gravity.END;
             holder.layoutChatFloor1.setLayoutParams(floor1LayoutParams);
             holder.layoutChatFloor2.setLayoutParams(floor2LayoutParams);
-        } else {
+
+            holder.chatTimeLeft.setText(mDataset.get(position).time);
+            holder.chatTimeRight.setText("");
+        } else {  // 다른 사람이 보낸 메시지일 경우
             holder.layoutChatObject.setGravity(Gravity.START);
             holder.layoutChatContainer.setBackgroundResource(chat_box_you);
 
@@ -79,8 +85,10 @@ public class ChatAdapter extends RecyclerView.Adapter<ChatAdapter.MyViewHolder> 
             floor2LayoutParams.gravity = Gravity.START;
             holder.layoutChatFloor1.setLayoutParams(floor1LayoutParams);
             holder.layoutChatFloor2.setLayoutParams(floor2LayoutParams);
-        }
 
+            holder.chatTimeRight.setText(mDataset.get(position).time);
+            holder.chatTimeLeft.setText("");
+        }
     }
 
     // Return the size of your dataset (invoked by the layout manager)

--- a/app/src/main/res/layout/chat_object.xml
+++ b/app/src/main/res/layout/chat_object.xml
@@ -11,9 +11,9 @@
         android:id="@+id/layout_chat_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:background="@drawable/chat_box_you"
         android:gravity="start"
-        android:orientation="vertical"
-        android:background="@drawable/chat_box_you">
+        android:orientation="vertical">
 
         <LinearLayout
             android:id="@+id/layout_chat_floor1"
@@ -27,7 +27,6 @@
                 android:id="@+id/chat_time_left"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginEnd="5dp"
                 android:text="@string/text_chat_time"
                 android:textColor="@color/colorWhite"
                 android:textSize="12sp"/>
@@ -44,7 +43,6 @@
                 android:id="@+id/chat_time_right"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="5dp"
                 android:text="@string/text_chat_time"
                 android:textColor="@color/colorWhite"
                 android:textSize="12sp"/>

--- a/app/src/main/res/layout/chat_object.xml
+++ b/app/src/main/res/layout/chat_object.xml
@@ -3,24 +3,34 @@
     android:id="@+id/layout_chat_object"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="start"
     android:layout_marginTop="10dp"
+    android:gravity="start"
     android:orientation="vertical">
 
     <LinearLayout
         android:id="@+id/layout_chat_container"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:gravity="start"
         android:orientation="vertical"
-        android:gravity="start">
+        android:background="@drawable/chat_box_you">
 
         <LinearLayout
             android:id="@+id/layout_chat_floor1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:orientation="horizontal"
             android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp">
+            android:layout_marginEnd="20dp"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/chat_time_left"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="5dp"
+                android:text="@string/text_chat_time"
+                android:textColor="@color/colorWhite"
+                android:textSize="12sp"/>
 
             <TextView
                 android:id="@+id/chat_person"
@@ -31,13 +41,13 @@
                 android:textSize="15sp"/>
 
             <TextView
-                android:id="@+id/chat_time"
+                android:id="@+id/chat_time_right"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="5dp"
                 android:text="@string/text_chat_time"
-                android:textSize="12sp"
-                android:textColor="@color/colorWhite"/>
+                android:textColor="@color/colorWhite"
+                android:textSize="12sp"/>
 
         </LinearLayout>
 
@@ -45,10 +55,10 @@
             android:id="@+id/layout_chat_floor2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="1dp"
-            android:orientation="horizontal"
             android:layout_marginStart="20dp"
-            android:layout_marginEnd="20dp">
+            android:layout_marginTop="1dp"
+            android:layout_marginEnd="20dp"
+            android:orientation="horizontal">
 
             <TextView
                 android:id="@+id/chat_text"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -10,6 +10,7 @@
     <dimen name="marginBottom_title">30dp</dimen>
     <dimen name="marginStart_text_above_rounded_rectangle">10.5dp</dimen>
     <dimen name="marginBottom_text_above_rounded_rectangle">5dp</dimen>
+    <dimen name="margin_between_name_time">5dp</dimen>
 
     <!-- padding -->
     <dimen name="paddingStart_rounded_rectangle">10dp</dimen>


### PR DESCRIPTION
보낸 사람과 관계없이 채팅방 말풍선이 이름 - 시간 순으로 표시되었던 문제를 해결함.
-
* 상대방: 이름 - 시간
* 나: 시간 - 이름

closes: #81 

> activity_chat
>
> ![Screenshot_1572534004](https://user-images.githubusercontent.com/48079406/67958527-a7800b00-fc3a-11e9-8996-0314f6b8dab4.png)

