### PR TITLE
fix(UI): Redesigned my club tab in main screen

### DIFF
--- a/app/src/main/res/drawable/button_join.xml
+++ b/app/src/main/res/drawable/button_join.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_pressed="false">
+        <layer-list>
+            <item>
+                <shape android:shape="oval">
+                    <solid android:color="@android:color/holo_blue_dark"/>
+                </shape>
+            </item>
+            <item android:drawable="@drawable/ic_arrow_forward_white"/>
+        </layer-list>
+    </item>
+    <item android:state_pressed="true">
+        <layer-list>
+            <item>
+                <shape android:shape="oval">
+                    <solid android:color="@color/colorGrey"/>
+                </shape>
+            </item>
+            <item android:drawable="@drawable/ic_arrow_forward_white"/>
+        </layer-list>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/ic_arrow_forward_white.xml
+++ b/app/src/main/res/drawable/ic_arrow_forward_white.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#FFFFFF"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M12,4l-1.41,1.41L16.17,11H4v2h12.17l-5.58,5.59L12,20l8,-8z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_class_black.xml
+++ b/app/src/main/res/drawable/ic_class_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M18,2H6c-1.1,0 -2,0.9 -2,2v16c0,1.1 0.9,2 2,2h12c1.1,0 2,-0.9 2,-2V4c0,-1.1 -0.9,-2 -2,-2zM6,4h5v8l-2.5,-1.5L6,12V4z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_gender_black.xml
+++ b/app/src/main/res/drawable/ic_gender_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M5.5,22v-7.5L4,14.5L4,9c0,-1.1 0.9,-2 2,-2h3c1.1,0 2,0.9 2,2v5.5L9.5,14.5L9.5,22h-4zM18,22v-6h3l-2.54,-7.63C18.18,7.55 17.42,7 16.56,7h-0.12c-0.86,0 -1.63,0.55 -1.9,1.37L12,16h3v6h3zM7.5,6c1.11,0 2,-0.89 2,-2s-0.89,-2 -2,-2 -2,0.89 -2,2 0.89,2 2,2zM16.5,6c1.11,0 2,-0.89 2,-2s-0.89,-2 -2,-2 -2,0.89 -2,2 0.89,2 2,2z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_school_black.xml
+++ b/app/src/main/res/drawable/ic_school_black.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M5,13.18v4L12,21l7,-3.82v-4L12,17l-7,-3.82zM12,3L1,9l11,6 9,-4.91V17h2V9L12,3z"/>
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -111,22 +111,9 @@
                             android:layout_height="match_parent"
                             android:layout_weight="1"/>
 
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:orientation="horizontal">
-
-                            <Button
-                                android:id="@+id/btn_go_school"
-                                android:layout_width="80dp"
-                                android:layout_height="35dp"
-                                android:background="@android:color/holo_blue_dark"
-                                android:text="@string/action_join"
-                                android:textColor="#FFFFFF"
-                                android:textSize="15sp"/>
-
-                        </LinearLayout>
+                        <Button
+                            android:id="@+id/btn_go_school"
+                            style="@style/JoinButton"/>
 
                     </LinearLayout>
 
@@ -164,22 +151,9 @@
                             android:layout_height="match_parent"
                             android:layout_weight="1"/>
 
-                        <LinearLayout
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center"
-                            android:orientation="horizontal">
-
                             <Button
                                 android:id="@+id/btn_go_class"
-                                android:layout_width="80dp"
-                                android:layout_height="35dp"
-                                android:background="@android:color/holo_blue_dark"
-                                android:text="@string/action_join"
-                                android:textColor="#FFFFFF"
-                                android:textSize="15sp"/>
-
-                        </LinearLayout>
+                                style="@style/JoinButton"/>
 
                     </LinearLayout>
 
@@ -225,12 +199,7 @@
 
                             <Button
                                 android:id="@+id/btn_go_gender"
-                                android:layout_width="80dp"
-                                android:layout_height="35dp"
-                                android:background="@android:color/holo_blue_dark"
-                                android:text="@string/action_join"
-                                android:textColor="#FFFFFF"
-                                android:textSize="15sp"/>
+                                style="@style/JoinButton"/>
 
                         </LinearLayout>
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -131,8 +131,8 @@
 
                         <ImageView
                             style="@style/RoomImage"
-                            app:srcCompat="@drawable/ic_class_black"
-                            android:contentDescription="@string/cd_icon_class"/>
+                            android:contentDescription="@string/cd_icon_class"
+                            app:srcCompat="@drawable/ic_class_black"/>
 
                         <LinearLayout
                             android:layout_width="wrap_content"
@@ -177,8 +177,8 @@
 
                         <ImageView
                             style="@style/RoomImage"
-                            app:srcCompat="@drawable/ic_gender_black"
-                            android:contentDescription="@string/cd_icon_gender" />
+                            android:contentDescription="@string/cd_icon_gender"
+                            app:srcCompat="@drawable/ic_gender_black" />
 
                         <LinearLayout
                             android:layout_width="wrap_content"
@@ -197,6 +197,7 @@
                                 android:id="@+id/my_gender"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:layout_marginStart="2dp"
                                 android:layout_marginEnd="2dp"
                                 android:text="@string/sample_gender"
                                 android:textColor="#000000"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -4,9 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/colorWhite"
     android:orientation="vertical"
-    tools:context=".MainActivity"
-    android:background="@color/colorWhite">
+    tools:context=".MainActivity">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -46,7 +46,7 @@
             android:layout_height="30dp"
             android:layout_gravity="center"
             android:layout_marginEnd="40dp"
-            android:contentDescription="@string/image_main_user"
+            android:contentDescription="@string/cd_main_user"
             app:srcCompat="@drawable/icon_user_black"/>
 
     </LinearLayout>
@@ -83,6 +83,11 @@
                         android:layout_height="wrap_content"
                         android:orientation="horizontal">
 
+                        <ImageView
+                            style="@style/RoomImage"
+                            android:contentDescription="@string/cd_icon_school"
+                            app:srcCompat="@drawable/ic_school_black" />
+
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -100,6 +105,7 @@
                                 android:id="@+id/my_school"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:layout_marginStart="2dp"
                                 android:text="@string/sample_school"
                                 android:textColor="#000000"
                                 android:textSize="15sp"/>
@@ -123,6 +129,11 @@
                         android:layout_marginTop="15dp"
                         android:orientation="horizontal">
 
+                        <ImageView
+                            style="@style/RoomImage"
+                            app:srcCompat="@drawable/ic_class_black"
+                            android:contentDescription="@string/cd_icon_class"/>
+
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -140,6 +151,7 @@
                                 android:id="@+id/my_class"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:layout_marginStart="2dp"
                                 android:text="@string/sample_class"
                                 android:textColor="#000000"
                                 android:textSize="15sp"/>
@@ -163,6 +175,11 @@
                         android:layout_marginTop="15dp"
                         android:orientation="horizontal">
 
+                        <ImageView
+                            style="@style/RoomImage"
+                            app:srcCompat="@drawable/ic_gender_black"
+                            android:contentDescription="@string/cd_icon_gender" />
+
                         <LinearLayout
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
@@ -180,6 +197,7 @@
                                 android:id="@+id/my_gender"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
+                                android:layout_marginEnd="2dp"
                                 android:text="@string/sample_gender"
                                 android:textColor="#000000"
                                 android:textSize="15sp"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -83,7 +83,10 @@
     <string name="text_main_my_class">나의 반</string>
     <string name="text_main_my_gender">나의 성별</string>
     <string name="text_main_friend">친구</string>
-    <string name="image_main_user">user image</string>
+    <string name="cd_main_user">user image</string>
+    <string name="cd_icon_school">school icon</string>
+    <string name="cd_icon_class">class icon</string>
+    <string name="cd_icon_gender">gender icon</string>
 
     <!-- activity_chat -->
     <string name="hint_chat_type_message">메시지를 입력하세요…</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,4 +25,11 @@
         <item name="android:layout_gravity">center</item>
     </style>
 
+    <style name="RoomImage">
+        <item name="android:layout_width">50dp</item>
+        <item name="android:layout_height">50dp</item>
+        <item name="android:layout_gravity">center</item>
+        <item name="android:layout_marginEnd">20dp</item>
+    </style>
+
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -17,4 +17,12 @@
 
     <style name="PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 
+
+    <style name="JoinButton">
+        <item name="android:layout_width">40dp</item>
+        <item name="android:layout_height">40dp</item>
+        <item name="android:background">@drawable/button_join</item>
+        <item name="android:layout_gravity">center</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
메인 화면의 '내 클럽' 탭의 디자인 수정
-
* '참가' 버튼을 화살표 모양 둥근 버튼으로 대체
* 방 이름 좌측에 아이콘 추가

closes: #89

> activity_main
>
> ![Screenshot_1572579462](https://user-images.githubusercontent.com/48079406/68000680-691f3600-fca4-11e9-958a-14738f451d3f.png)
