### PR TITLE
fix: clear EditText editID, editPW when login is successful

### DIFF
--- a/app/src/main/java/com/example/soenapp/LoginActivity.java
+++ b/app/src/main/java/com/example/soenapp/LoginActivity.java
@@ -100,6 +100,9 @@ public class LoginActivity extends AppCompatActivity {
                                 editor.putString("school_class", schoolClassValue);
                                 editor.apply();
 
+                                editID.setText(null);
+                                editPW.setText(null);
+
                                 final Intent intent = new Intent(getApplicationContext(), MainActivity.class);
                                 startActivity(intent);
 


### PR DESCRIPTION
### 로그인이 성공적으로 완료되었을 때 아이디, 비밀번호 입력 칸을 지움.

closes: #99 